### PR TITLE
fix: CICD env file value added 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,6 +98,7 @@ jobs:
           DATABASE_USERNAME=${{ secrets.DATABASE_USERNAME }}
           DATABASE_PASSWORD=${{ secrets.DATABASE_PASSWORD }}
           EC2_PORT=${{ secrets.EC2_PORT }}
+          JWT_SECRET=${{ secrets.JWT_SECRET }}
           NODE_ENV=production
           EOF"
 


### PR DESCRIPTION
### Pull Request 템플릿

## 🔗 관련 이슈 번호
- 관련 이슈: #25 

---

## ✅ 작업 유형 (Tag)

- [ ] ✨ Feature 
- [X] 🐛 Fix 
- [ ] 🔨 Refactoring 
- [ ] 📝 Docs 

---

## ✏️ 수정 사항 및 개선 내용

* CICD 자체 코드 에러인 줄 알았으나
<pre>
  shell: /usr/bin/bash -e {0}
ssh: connect to host *** port 22: Connection timed out
Error: Process completed with exit code 255.
</pre>

단순 port 22 즉 SSH 연결에서 막힌다는 부분을 알았음

원인 1. EC2에서 상태 검사가 2/2로 정상 작동 되어야하지만 1/2로 SSH 연결에서 에러가 뜬다는 것을 발견
원인 2. LocalHost port와 RDS port가 동일해 3306 port 어플리케이션 충돌 에러가 발생하였다.

<pre>
com. intellij. execution. ExecutionException: SSH: Failed to create local tunnel for SshjSshConnection(ubuntu@EC2 address)@3108f799: localhost/ 127.0.0.1:3306 ==> dataBase:3306: Address already in use: bind


SSH: Failed to create local tunnel for SshjSshConnection(ubuntu@EC2 address)@3108f799: localhost/ 127.0.0.1:3306 ==> coffect-database. database endpoint:3306: Address already in use: bind.
</pre>

해결 방법 1. *local에서 3306 포트를 사용 중이라면 그 PID (Process ID)값을 죽이는 방법
* lsof -i 3306
* kill -9 [PID num]
 -> 결론적으로 실패
  DataGrip에서 추가적인 3306을 사용한다고 판단. (터미널 상에서는 3306 PID를 모두 죽이긴 했음)

해결 방법 2. LocalHost port와 RDS port 값을 각각 다르게 설정하함.
* localhost port : 3307
* RDS post : 3306
-> 성공

결론.
원초적으로는 SSH 연결 자체에서 문제이기 때문에 .env 파일에서는 환경변수 JWT_SECRET을 추가해주었음.
---

## ⚠️ 문제 발생 여부 및 상세 위치

- [ ] 문제 없음
- [X] 문제 발생함

* 발생 가능성이 존재함.
* CICD 코드 자체에서 에러가 발생하면 문제가 존재함...

---

## 📋 TODO List

## 📚 참고 문헌
https://support.bespinglobal.com/ko/support/solutions/articles/73000615454--aws-%EC%9D%B8%EC%8A%A4%ED%84%B4%EC%8A%A4-ssh-%EC%A0%91%EC%86%8D-%EC%98%A4%EB%A5%98-ec2-
