### PR TITLE
[feat] /profile의 profile 상세 조회 기능 추가

### DIFF
--- a/src/middleware/detailProfile.DTO/detailProfile.DTO.ts
+++ b/src/middleware/detailProfile.DTO/detailProfile.DTO.ts
@@ -1,4 +1,5 @@
 import { Example } from 'tsoa';
+import { specifyProfileDTO } from '../follow.DTO/follow.DTO';
 
 type UserInfo = {
   name: string;
@@ -29,6 +30,24 @@ export class ProfileDTO {
     this.follower = data[2];
     this.userInfo = data[3] as UserInfo;
     this.interest = data[4] as Category[];
+  }
+}
+
+export class AllProfileDTO {
+  threadCount: number;
+  following: number;
+  follower: number;
+  userInfo: UserInfo;
+  interest: Category[];
+  specifyProfile: { question: string; answer: string; isMain: boolean }[];
+
+  constructor(data: [number, number, number, object, object[], object[]]) {
+    this.threadCount = data[0];
+    this.following = data[1];
+    this.follower = data[2];
+    this.userInfo = data[3] as UserInfo;
+    this.interest = data[4] as Category[];
+    this.specifyProfile = data[5] as { question: string; answer: string; isMain: boolean }[];
   }
 }
 

--- a/src/profile/profile.Controller.ts
+++ b/src/profile/profile.Controller.ts
@@ -25,7 +25,8 @@ import {
   ProfileDTO,
   ProfileUpdateDTO,
   DetailProfileBody,
-  UpdateProfileBody
+  UpdateProfileBody,
+  AllProfileDTO
 } from '../middleware/detailProfile.DTO/detailProfile.DTO';
 import { ResponseFromSingleThreadWithLikes } from '../middleware/thread.DTO/thread.DTO';
 import { UserModel } from '../user/user.Model';
@@ -60,7 +61,7 @@ export class ProfileController extends Controller {
   @Security('jwt_token')
   public async myProfile(
     @Request() req: Express.Request
-  ): Promise<ITsoaSuccessResponse<ProfileDTO>> {
+  ): Promise<ITsoaSuccessResponse<AllProfileDTO>> {
     const userId = req.user.index;
     const data = await this.profileService.myProfile(userId);
     return new TsoaSuccessResponse(data);

--- a/src/profile/profile.Model.ts
+++ b/src/profile/profile.Model.ts
@@ -21,6 +21,7 @@ export class ProfileModel {
         prisma.user.findFirst({
           where: { userId: userId },
           select: {
+            userId: true,
             id: true,
             name: true,
             introduce: true,
@@ -44,6 +45,12 @@ export class ProfileModel {
                 categoryColor: true
               }
             }
+          }
+        }),
+        prisma.specifyInfo.findFirst({
+          where: { userId: userId },
+          select: {
+            info: true
           }
         })
       ]);
@@ -77,7 +84,8 @@ export class ProfileModel {
             }
           }
         }),
-        [] // 카테고리 대신 빈 배열 반환
+        [], // 카테고리 대신 빈 배열 반환
+        [] // 특정 정보 대신 빈 배열 반환
       ]);
       return data;
     }

--- a/src/profile/profile.Service.ts
+++ b/src/profile/profile.Service.ts
@@ -2,7 +2,8 @@ import { deleteFromS3, uploadToS3 } from '../config/s3';
 import {
   ProfileDTO,
   ProfileUpdateDTO,
-  DetailProfileBody
+  DetailProfileBody,
+  AllProfileDTO
 } from '../middleware/detailProfile.DTO/detailProfile.DTO';
 import { ResponseFromSingleThreadWithLikes } from '../middleware/thread.DTO/thread.DTO';
 import { UserModel } from '../user/user.Model';
@@ -19,13 +20,13 @@ export class ProfileService {
 
   public async myProfile(userId: number) {
     const data = await this.profileModel.selectUserProfile(userId);
-    return new ProfileDTO(data as [number, number, number, object, object[]]);
+    return new AllProfileDTO(data as [number, number, number, object, object[], object[]]);
   }
 
   public async getProfile(id: string) {
     const user = await new UserModel().selectUserInfo(id);
     const data = await this.profileModel.selectUserProfile(user?.userId!);
-    return new ProfileDTO(data as [number, number, number, object, object[]]);
+    return new AllProfileDTO(data as [number, number, number, object, object[], object[]]);
   }
 
   public async getThread(id?: string, userIndex?: number) {


### PR DESCRIPTION
### Pull Request 템플릿

## 🔗 관련 이슈 번호

> 이 PR이 연결된 이슈가 있다면 번호를 작성해주세요. (`#123` 형식)

- 관련 이슈: #121 

---

## ✅ 작업 유형 (Tag)

- [X] ✨ Feature 
- [ ] 🐛 Fix 
- [ ] 🔨 Refactoring 
- [ ] 📝 Docs 

---

## ✏️ 수정 사항 및 개선 내용

> 어떤 내용을 수정하거나 개선했는지 상세히 작성해주세요.

<pre>
<code>
export class AllProfileDTO {
  threadCount: number;
  following: number;
  follower: number;
  userInfo: UserInfo;
  interest: Category[];
  specifyProfile: { question: string; answer: string; isMain: boolean }[];

  constructor(data: [number, number, number, object, object[], object[]]) {
    this.threadCount = data[0];
    this.following = data[1];
    this.follower = data[2];
    this.userInfo = data[3] as UserInfo;
    this.interest = data[4] as Category[];
    this.specifyProfile = data[5] as { question: string; answer: string; isMain: boolean }[];
  }
}
</code>
</pre>

ProfileDTO를 AllProfileDTO로 수정하여 상세 프로필 조회까지 가능하도록 수정
/profile 라우터에서 모든 정보를 한번에 받을 수 있게 수정하였음.


---

## ⚠️ 문제 발생 여부 및 상세 위치

- [ ] 문제 없음
- [ ] 문제 발생함

> 문제가 발생한 경우 어떤 코드/상황에서 발생했는지 구체적으로 작성해주세요.

예시:
- user.Server.ts에서 CORS 오류 발생
- Prisma client 관련 의존성 충돌

---

## 📋 TODO List

> 남은 작업이나 추가로 처리해야 할 항목이 있다면 체크리스트로 작성해주세요.

- [ ] 테스트 코드 작성
- [ ] Swagger 문서 반영
- [ ] 코드 리뷰 반영
- [ ] 배포 전 최종 확인
