### PR TITLE
[refactor] 게시글 조회 api 분리

### DIFF
--- a/src/middleware/thread.DTO/thread.DTO.ts
+++ b/src/middleware/thread.DTO/thread.DTO.ts
@@ -25,19 +25,15 @@ export class BodyToAddThread {
 }
 
 export class BodyToLookUpMainThread {
-  type?: Thread_type;
-  threadSubject?: number[];
-  ascend: boolean;
+  type: Thread_type;
+  threadSubject: number[];
   orderBy: 'createdAt' | 'likeCount';
-  likeCursor?: number;
   dateCursor?: Date;
 
   constructor(
     body: {
-      type?: Thread_type;
-      threadSubject?: number[];
-      ascend?: boolean;
-      likeCursor?: number;
+      type: Thread_type;
+      threadSubject: number[];
       dateCursor?: Date;
       orderBy?: 'createdAt' | 'likeCount';
     }
@@ -45,8 +41,6 @@ export class BodyToLookUpMainThread {
     this.type = body.type;
     this.orderBy = body.orderBy ?? 'createdAt'; // 기본값은 createdAt
     this.threadSubject = body.threadSubject ?? []; // 기본값은 빈 배열
-    this.ascend = body.ascend ?? true; // 기본값은 오름차순
-    this.likeCursor = body.likeCursor;
     this.dateCursor = body.dateCursor;
   }
 }
@@ -212,6 +206,44 @@ export interface ResponseFromGetComment {
     studentId: number | null;
   }
 }
+
+export const defaultThreadSelect = {
+  threadId: true,
+  userId: true,
+  type: true,
+  threadTitle: true,
+  thradBody: true,
+  createdAt: true,
+  threadShare: true,
+  user: {
+    select: {
+      name: true,
+      profileImage: true,
+      studentId: true,
+      dept: true
+    }
+  },
+  subjectMatch: {
+    select: {
+      threadSubject: {
+        select: {
+          subjectName: true
+        }
+      }
+    }
+  },
+  images: {
+    select: {
+      imageId: true
+    }
+  },
+  _count: {
+    select: {
+      comments: true,
+      likes: true
+    }
+  }
+};
 
 export enum ThreadType {
   article = '아티클',

--- a/src/thread/thread.Controller.ts
+++ b/src/thread/thread.Controller.ts
@@ -224,11 +224,9 @@ export class ThreadController extends Controller {
   })
   public async mainThread(
     @Body() body: {
-      type?: Thread_type;
-      threadSubject?: number[];
+      type: Thread_type;
+      threadSubject: number[];
       orderBy: 'createdAt' | 'likeCount';
-      ascend: boolean;
-      likeCursor?: number;
       dateCursor?: Date;
     }
   ): Promise<ITsoaSuccessResponse<ResponseFromThreadMainCursorToClient>> {
@@ -237,6 +235,22 @@ export class ThreadController extends Controller {
     }
 
     const result = await this.ThreadService.lookUpThreadMainService(new BodyToLookUpMainThread(body));
+
+    return new TsoaSuccessResponse<ResponseFromThreadMainCursorToClient>(result);
+  }
+
+  /**
+   * 게시글 최신순조회 API
+   * @param dateCursor - 최신순 커서 페이지네이션
+   * @summary 게시글 최신순조회
+   * @returns 게시글 목록
+   */
+  @Get('latest')
+  @SuccessResponse('200', '게시글 최신순조회 성공')
+  public async getLatest(
+    @Query() dateCursor?: Date
+  ): Promise<ITsoaSuccessResponse<ResponseFromThreadMainCursorToClient>>{
+    const result = await this.ThreadService.lookUpLatestThreadMainService(dateCursor);
 
     return new TsoaSuccessResponse<ResponseFromThreadMainCursorToClient>(result);
   }

--- a/src/thread/thread.Service.ts
+++ b/src/thread/thread.Service.ts
@@ -12,6 +12,7 @@ import {
   ResponseFromGetComment, 
   ResponseFromPostComment, 
   ResponseFromSingleThreadWithLikes, 
+  ResponseFromThreadMain, 
   ResponseFromThreadMainCursor, 
   ResponseFromThreadMainCursorToClient, 
   ResponseFromThreadMainToClient
@@ -88,6 +89,22 @@ export class ThreadService {
 
     if (!results || results.thread.length === 0) {
       throw new ThreadNotFoundError(`필터링 된 게시글이 없습니다. type: ${body.type}, subjects: ${body.threadSubject}`);
+    }
+
+    return {thread, nextCursor: results.nextCursor};
+  };
+
+  public lookUpLatestThreadMainService = async (
+    dateCursor?: Date
+  ): Promise<ResponseFromThreadMainCursorToClient> => {
+    const results: ResponseFromThreadMainCursor = await this.ThreadModel.lookUpLatestThreadMainRepository(dateCursor);
+
+    const thread: ResponseFromThreadMainToClient[] = results.thread.map((thread: any) => {
+      return new ResponseFromThreadMainToClient(thread);
+    });
+
+    if (!results || results.thread.length === 0) {
+      throw new ThreadNotFoundError('최신 게시글이 없습니다.');
     }
 
     return {thread, nextCursor: results.nextCursor};


### PR DESCRIPTION
### Pull Request 템플릿

## 🔗 관련 이슈 번호

> 이 PR이 연결된 이슈가 있다면 번호를 작성해주세요. (`#123` 형식)

예시:
- 관련 이슈: #45
#134 

---

## ✅ 작업 유형 (Tag)

- [ ] ✨ Feature 
- [ ] 🐛 Fix 
- [ ] 🔨 Refactoring 
- [ ] 📝 Docs 

---

## ✏️ 수정 사항 및 개선 내용

> 어떤 내용을 수정하거나 개선했는지 상세히 작성해주세요.

예시:
- 로그인 API에서 JWT 생성 방식 변경
- 응답 형식에 `userId` 추가

게시글 조회 api를 필터링 여부에 따라 2개의 api로 나눴습니다.
하나는 최신순 정렬로 조회하고, 하나는 필터링된 결과를 조회합니다.

---

## ⚠️ 문제 발생 여부 및 상세 위치

- [ ] 문제 없음
- [ ] 문제 발생함

> 문제가 발생한 경우 어떤 코드/상황에서 발생했는지 구체적으로 작성해주세요.

예시:
- user.Server.ts에서 CORS 오류 발생
- Prisma client 관련 의존성 충돌

---

## 📋 TODO List

> 남은 작업이나 추가로 처리해야 할 항목이 있다면 체크리스트로 작성해주세요.

- [ ] 테스트 코드 작성
- [ ] Swagger 문서 반영
- [ ] 코드 리뷰 반영
- [ ] 배포 전 최종 확인
