### PR TITLE
[feat] 채팅방 기능 추가

### DIFF
--- a/prisma/mongodb/schema.prisma
+++ b/prisma/mongodb/schema.prisma
@@ -11,11 +11,12 @@ datasource db {
 model Message {
   id        String   @id @default(auto()) @map("_id") @db.ObjectId
   userId  Int
-  chatRoodId String
+  chatRoomId String
+  isPhoto Boolean @default(false)
   messageBody   String
   createdAt DateTime @default(now())
   check Boolean @default(false)
   
   @@index([userId], map: "Message_senderId_idx")
-  @@index([chatRoodId], map: "Message_chatRoomId_idx")
+  @@index([chatRoomId], map: "Message_chatRoomId_idx")
 }

--- a/prisma/mysql/schema.prisma
+++ b/prisma/mysql/schema.prisma
@@ -264,12 +264,13 @@ model UserFCMToken {
 }
 
 model ChatRoomUser {
-  id                Int      @id @default(autoincrement())
-  userId            Int
-  chatroomId        String   @db.VarChar(100)
-  lastReadMessageId Int?
-  User              User     @relation(fields: [userId], references: [userId], onDelete: NoAction, onUpdate: NoAction, map: "ChatRoomUser_User_userId_fk")
-  ChatRoom          ChatRoom @relation(fields: [chatroomId], references: [chatroomId], onDelete: Cascade, onUpdate: NoAction, map: "fk_chatroomuser_chatroom")
+  id          Int      @id @default(autoincrement())
+  userId      Int
+  chatroomId  String   @db.VarChar(100)
+  lastMessage String?  @db.VarChar(50)
+  check       Boolean?
+  User        User     @relation(fields: [userId], references: [userId], onDelete: NoAction, onUpdate: NoAction, map: "ChatRoomUser_User_userId_fk")
+  ChatRoom    ChatRoom @relation(fields: [chatroomId], references: [chatroomId], onDelete: Cascade, onUpdate: NoAction, map: "fk_chatroomuser_chatroom")
 
   @@index([userId], map: "ChatRoomUser_User_userId_fk")
   @@index([chatroomId], map: "fk_chatroomuser_chatroom")

--- a/src/chat/chat.Controller.ts
+++ b/src/chat/chat.Controller.ts
@@ -23,7 +23,7 @@ import {
   TsoaSuccessResponse
 } from '../config/tsoaResponse';
 import { ChatService } from './chat.Service';
-import { ChatRoomDTO } from '../middleware/chat.DTO/chat.DTO';
+import { ChatRoomsDTO } from '../middleware/chat.DTO/chat.DTO';
 
 @Route('chat')
 @Tags('Chat Controller')
@@ -63,8 +63,24 @@ export class ChatController extends Controller {
     return new TsoaSuccessResponse<{ chatRoomId: string }>(chatRoomId);
   }
 
+  // /**
+  //  * 채팅방의 메시지를 조회한다.
+  //  * @summary 채팅방 메시지 조회
+  //  */
+  // @Get('/:chatRoomId/messages')
+  // @Security('jwt_token')
+  // public async getMessages(
+  //   @Request() req: ExpressRequest,
+  //   @Query() chatRoomId: string
+  // ): Promise<ITsoaSuccessResponse<string[]>> {
+  //   const userId = req.user.index;
+  //   const result = await this.chatService.getMessages(userId, chatRoomId);
+  //   return new TsoaSuccessResponse<string[]>(result);
+  // }
+
   /**
    * 유저가 속해있는 모든 채팅방 목록을 조회한다.
+   * 해당 chatRoomId, 상대방 유저의 userId, 마지막으로 보낸 메시지의 lastReadMessageId를 반환한다.
    * @summary 채팅방 목록 조회
    */
   @Get('/rooms')
@@ -81,9 +97,9 @@ export class ChatController extends Controller {
   })
   public async getChatRoom(
     @Request() req: ExpressRequest
-  ): Promise<ITsoaSuccessResponse<string[]>> {
+  ): Promise<ITsoaSuccessResponse<ChatRoomsDTO[]>> {
     const userId = req.user.index;
     const result = await this.chatService.getChatRoom(userId);
-    return new TsoaSuccessResponse<string[]>(result);
+    return new TsoaSuccessResponse<ChatRoomsDTO[]>(result);
   }
 }

--- a/src/chat/chat.Controller.ts
+++ b/src/chat/chat.Controller.ts
@@ -53,7 +53,7 @@ export class ChatController extends Controller {
   public async makeChatRoom(
     @Request() req: ExpressRequest,
     @Body()
-    body: {
+      body: {
       userId: number;
     }
   ): Promise<ITsoaSuccessResponse<{ chatRoomId: string }>> {

--- a/src/chat/chat.Controller.ts
+++ b/src/chat/chat.Controller.ts
@@ -23,7 +23,7 @@ import {
   TsoaSuccessResponse
 } from '../config/tsoaResponse';
 import { ChatService } from './chat.Service';
-import { ChatRoomsDTO } from '../middleware/chat.DTO/chat.DTO';
+import { ChatDataDTO, ChatRoomsDTO } from '../middleware/chat.DTO/chat.DTO';
 
 @Route('chat')
 @Tags('Chat Controller')
@@ -53,7 +53,7 @@ export class ChatController extends Controller {
   public async makeChatRoom(
     @Request() req: ExpressRequest,
     @Body()
-    body: {
+      body: {
       userId: number;
     }
   ): Promise<ITsoaSuccessResponse<{ chatRoomId: string }>> {
@@ -103,12 +103,17 @@ export class ChatController extends Controller {
     return new TsoaSuccessResponse<ChatRoomsDTO[]>(result);
   }
 
-  @Post('/:chatRoomId/message')
+  /**
+   * 채팅방에 메시지를 전송한다.
+   * chatRoomId를 기반으로 message를 받아 전송한다.
+   * @summary 채팅방 메시지 조회
+   */
+  @Post('/message')
   @Security('jwt_token')
   @SuccessResponse(200, '메시지 전송 성공')
   public async sendMessage(
-    @Request() req: ExpressRequest,
     @Query() chatRoomId: string,
+    @Request() req: ExpressRequest,
     @Body() body: { message: string }
   ): Promise<ITsoaSuccessResponse<string>> {
     const userId = req.user.index;
@@ -118,5 +123,21 @@ export class ChatController extends Controller {
       body.message
     );
     return new TsoaSuccessResponse<string>('메시지 전송 성공');
+  }
+
+  /**
+   * 채팅방의 메시지를 조회한다.
+   * 특정 chatRoomId에 있는 메시지를 조회한다.
+   * @summary 채팅방 메시지 조회
+   */
+  @Get('/')
+  @Security('jwt_token')
+  @SuccessResponse(200, '채팅방 정보 조회 성공')
+  public async getChatRoomInfo(
+    @Request() req: ExpressRequest,
+    @Query() chatRoomId: string
+  ): Promise<ITsoaSuccessResponse<ChatDataDTO[]>> {
+    const result = await this.chatService.getChatRoomInfo(chatRoomId);
+    return new TsoaSuccessResponse<ChatDataDTO[]>(result);
   }
 }

--- a/src/chat/chat.Controller.ts
+++ b/src/chat/chat.Controller.ts
@@ -102,4 +102,21 @@ export class ChatController extends Controller {
     const result = await this.chatService.getChatRoom(userId);
     return new TsoaSuccessResponse<ChatRoomsDTO[]>(result);
   }
+
+  @Post('/:chatRoomId/message')
+  @Security('jwt_token')
+  @SuccessResponse(200, '메시지 전송 성공')
+  public async sendMessage(
+    @Request() req: ExpressRequest,
+    @Query() chatRoomId: string,
+    @Body() body: { message: string }
+  ): Promise<ITsoaSuccessResponse<string>> {
+    const userId = req.user.index;
+    const result = await this.chatService.sendMessage(
+      userId,
+      chatRoomId,
+      body.message
+    );
+    return new TsoaSuccessResponse<string>('메시지 전송 성공');
+  }
 }

--- a/src/chat/chat.Controller.ts
+++ b/src/chat/chat.Controller.ts
@@ -53,7 +53,7 @@ export class ChatController extends Controller {
   public async makeChatRoom(
     @Request() req: ExpressRequest,
     @Body()
-      body: {
+    body: {
       userId: number;
     }
   ): Promise<ITsoaSuccessResponse<{ chatRoomId: string }>> {
@@ -106,7 +106,7 @@ export class ChatController extends Controller {
   /**
    * 채팅방에 메시지를 전송한다.
    * chatRoomId를 기반으로 message를 받아 전송한다.
-   * @summary 채팅방 메시지 조회
+   * @summary 채팅방 메시지 전송
    */
   @Post('/message')
   @Security('jwt_token')

--- a/src/chat/chat.Message.ts
+++ b/src/chat/chat.Message.ts
@@ -11,3 +11,9 @@ export class ChatRoomAlreadyExists extends BasicError {
     super(409, 'EC409', '이미 채팅방이 존재합니다.', description);
   }
 }
+
+export class ChatRoomNotFound extends BasicError {
+  constructor(description: string) {
+    super(404, 'EC404', '채팅방을 찾을 수 없습니다.', description);
+  }
+}

--- a/src/chat/chat.Model.ts
+++ b/src/chat/chat.Model.ts
@@ -1,5 +1,5 @@
 import { KSTtime } from '../config/KSTtime';
-import { prisma } from '../config/prisma.config';
+import { mongo, prisma } from '../config/prisma.config';
 import { ChatRoomsDTO } from '../middleware/chat.DTO/chat.DTO';
 
 export class ChatModel {
@@ -39,7 +39,16 @@ export class ChatModel {
         lastReadMessageId: true
       }
     });
-
     return roomsInfo;
+  }
+
+  public async sendMessage(
+    userId: number,
+    chatRoomId: string,
+    message: string
+  ): Promise<void> {
+    await mongo.message.create({
+      data: { userId, chatRoomId: chatRoomId, messageBody: message }
+    });
   }
 }

--- a/src/chat/chat.Model.ts
+++ b/src/chat/chat.Model.ts
@@ -1,5 +1,6 @@
 import { KSTtime } from '../config/KSTtime';
 import { prisma } from '../config/prisma.config';
+import { ChatRoomsDTO } from '../middleware/chat.DTO/chat.DTO';
 
 export class ChatModel {
   public async makeChatRoom(
@@ -19,11 +20,26 @@ export class ChatModel {
     await prisma.$transaction([makeRoom, insertUser1, insertUser2]);
   }
 
-  public async getChatRoom(userId: number): Promise<string[]> {
+  public async getChatRoom(userId: number): Promise<ChatRoomsDTO[]> {
     const result = await prisma.chatRoomUser.findMany({
       where: { userId: userId },
-      select: { chatroomId: true }
+      select: {
+        chatroomId: true
+      }
     });
-    return result.map((chatroomId) => chatroomId.chatroomId);
+
+    const roomsInfo = await prisma.chatRoomUser.findMany({
+      where: {
+        userId: { not: userId },
+        chatroomId: { in: result.map((chatroomId) => chatroomId.chatroomId) }
+      },
+      select: {
+        chatroomId: true,
+        userId: true,
+        lastReadMessageId: true
+      }
+    });
+
+    return roomsInfo;
   }
 }

--- a/src/chat/chat.Model.ts
+++ b/src/chat/chat.Model.ts
@@ -49,7 +49,14 @@ export class ChatModel {
     message: string
   ): Promise<ChatDataDTO> {
     const data = await mongo.message.create({
-      data: { userId, chatRoomId: chatRoomId, messageBody: message }
+      data: {
+        userId,
+        chatRoomId: chatRoomId,
+        messageBody: message,
+        createdAt: KSTtime(),
+        isPhoto: false,
+        check: false
+      }
     });
     return data;
   }

--- a/src/chat/chat.Service.ts
+++ b/src/chat/chat.Service.ts
@@ -1,7 +1,7 @@
 import { ChatRoomsDTO } from '../middleware/chat.DTO/chat.DTO';
 import { ChatModel } from './chat.Model';
 import { pbkdf2Promise } from '../config/crypto';
-import { ChatRoomAlreadyExists } from './chat.Message';
+import { ChatRoomAlreadyExists, ChatRoomNotFound } from './chat.Message';
 
 export class ChatService {
   private chatModel: ChatModel;
@@ -33,5 +33,22 @@ export class ChatService {
   public async getChatRoom(userId: number): Promise<ChatRoomsDTO[]> {
     const result = await this.chatModel.getChatRoom(userId);
     return result;
+  }
+
+  public async sendMessage(
+    userId: number,
+    chatRoomId: string,
+    message: string
+  ): Promise<string> {
+    const chatRoom = await this.chatModel.getChatRoom(userId);
+    if (!chatRoom.some((room) => room.chatroomId === chatRoomId)) {
+      throw new ChatRoomNotFound(chatRoomId);
+    }
+    const result = await this.chatModel.sendMessage(
+      userId,
+      chatRoomId,
+      message
+    );
+    return '메시지 전송 성공';
   }
 }

--- a/src/chat/chat.Service.ts
+++ b/src/chat/chat.Service.ts
@@ -1,4 +1,4 @@
-import { ChatRoomDTO } from '../middleware/chat.DTO/chat.DTO';
+import { ChatRoomsDTO } from '../middleware/chat.DTO/chat.DTO';
 import { ChatModel } from './chat.Model';
 import { pbkdf2Promise } from '../config/crypto';
 import { ChatRoomAlreadyExists } from './chat.Message';
@@ -15,20 +15,22 @@ export class ChatService {
   ): Promise<{ chatRoomId: string }> {
     const usersRooms = await this.chatModel.getChatRoom(myId);
     const chatRoomId = await pbkdf2Promise(
+      // 유저 아이디를 조합해 난수 chatRoomId 생성
       myId.toString(),
       otherId.toString(),
       1000,
       32,
       'sha512'
     ).then((result) => result.toString('base64'));
-    if (usersRooms.includes(chatRoomId)) {
+    if (usersRooms.some((room) => room.chatroomId === chatRoomId)) {
+      // 이미 존재하는 채팅방이라면 예외 발생
       throw new ChatRoomAlreadyExists(chatRoomId);
     }
     await this.chatModel.makeChatRoom(myId, otherId, chatRoomId);
     return { chatRoomId };
   }
 
-  public async getChatRoom(userId: number): Promise<string[]> {
+  public async getChatRoom(userId: number): Promise<ChatRoomsDTO[]> {
     const result = await this.chatModel.getChatRoom(userId);
     return result;
   }

--- a/src/chat/chat.Service.ts
+++ b/src/chat/chat.Service.ts
@@ -1,4 +1,4 @@
-import { ChatRoomsDTO } from '../middleware/chat.DTO/chat.DTO';
+import { ChatDataDTO, ChatRoomsDTO } from '../middleware/chat.DTO/chat.DTO';
 import { ChatModel } from './chat.Model';
 import { pbkdf2Promise } from '../config/crypto';
 import { ChatRoomAlreadyExists, ChatRoomNotFound } from './chat.Message';
@@ -42,6 +42,7 @@ export class ChatService {
   ): Promise<string> {
     const chatRoom = await this.chatModel.getChatRoom(userId);
     if (!chatRoom.some((room) => room.chatroomId === chatRoomId)) {
+      // 내 채팅방 목록중에 존재하지 않는경우
       throw new ChatRoomNotFound(chatRoomId);
     }
     const result = await this.chatModel.sendMessage(
@@ -49,6 +50,13 @@ export class ChatService {
       chatRoomId,
       message
     );
+    await this.chatModel.updateLastSendMessage(result); // 해당 채팅방의 마지막 메시지 업데이트
     return '메시지 전송 성공';
+  }
+
+  public async getChatRoomInfo(chatRoomId: string): Promise<ChatDataDTO[]> {
+    // 채팅방에 존재하는 메시지들을 배열로 조회
+    const result = await this.chatModel.getChatRoomInfo(chatRoomId);
+    return result;
   }
 }

--- a/src/middleware/chat.DTO/chat.DTO.ts
+++ b/src/middleware/chat.DTO/chat.DTO.ts
@@ -1,5 +1,16 @@
 export interface ChatRoomsDTO {
   chatroomId: string;
   userId: number;
-  lastReadMessageId: number | null;
+  lastMessage: string | null;
+  check: boolean | null;
+}
+
+export interface ChatDataDTO {
+  id: string;
+  chatRoomId: string;
+  userId: number;
+  messageBody: string;
+  createdAt: Date;
+  isPhoto: boolean;
+  check: boolean;
 }

--- a/src/middleware/chat.DTO/chat.DTO.ts
+++ b/src/middleware/chat.DTO/chat.DTO.ts
@@ -1,3 +1,5 @@
-export interface ChatRoomDTO {
+export interface ChatRoomsDTO {
   chatroomId: string;
+  userId: number;
+  lastReadMessageId: number | null;
 }

--- a/src/socket/socket.model.ts
+++ b/src/socket/socket.model.ts
@@ -1,7 +1,7 @@
 import { prisma } from '../config/prisma.config';
 
 export class SocketModel {
-  public async getRooms(userId: number): Promise<{}[]> {
+  public async getRooms(userId: number): Promise<string[]> {
     const data = await prisma.chatRoomUser.findMany({
       where: { userId: userId },
       select: { chatroomId: true }

--- a/src/socket/socket.service.ts
+++ b/src/socket/socket.service.ts
@@ -10,7 +10,7 @@ export default class SocketService {
     const userId = socket.data.decoded.index;
     const rooms = await this.SocketModel.getRooms(userId);
     for (const room of rooms) {
-      await socket.join(room.toString());
+      await socket.join(room);
     }
   }
 }

--- a/src/socket/socket.ts
+++ b/src/socket/socket.ts
@@ -1,9 +1,11 @@
 import { Server } from 'socket.io';
 import { instrument } from '@socket.io/admin-ui';
 import SocketService from './socket.service';
+import { ChatService } from '../chat/chat.Service';
 
 export default function initSocket(io: Server) {
   const socketService = new SocketService();
+  const chatService = new ChatService();
   //socket.io 관리자 페이지 설정
   instrument(io, {
     auth: false,
@@ -11,24 +13,26 @@ export default function initSocket(io: Server) {
   });
 
   io.on('connection', async (socket) => {
-    console.log(`${socket.data.decoded.index} connected`);
+    const userId = socket.data.decoded.index;
+    const userName = socket.data.decoded.name;
+    console.log(`${userId} connected`);
     await socketService.joinRoom(socket);
 
-    socket.on('send', ({ message, roomId }) => {
+    socket.on('send', async ({ message, roomId }) => {
       //클라이언트가 roomID를 같이 보내주면 해당 방에 메시지를 보낸다 애초에 클라이언트는 해당 방의 정보를 미리 알고 있어야함
-      console.log(message, ' from ', socket.id);
-      socket.to(roomId).emit('receive', {
+      await chatService.sendMessage(userId, roomId, message);
+      //굳이 상대방이 있나 없나 체크할 필요가 없어보임,,
+      io.to(roomId).emit('receive', {
         //roomID를 먼저 만들고, 클라이언트에서 roomId를 생성해서 메세지 보내기
-        timeStampe: new Date().toISOString(),
-        sender: socket.id
+        sender: userId,
+        senderName: userName,
+        message: message
       });
     });
 
     // socket.on("typing",())
     // socket.on("seen",())
 
-    socket.on('disconnect', () => {
-      console.log(`${socket.id} disconnected`);
-    });
+    socket.on('disconnect', () => {});
   });
 }

--- a/src/thread/mongotest.Controller.ts
+++ b/src/thread/mongotest.Controller.ts
@@ -1,29 +1,19 @@
-import {mongo} from '../config/prisma.config';
-import {
-  Body,
-  Controller,
-  Post,
-  Route,
-  SuccessResponse
-} from 'tsoa';
+import { mongo } from '../config/prisma.config';
+import { Body, Controller, Post, Route, SuccessResponse } from 'tsoa';
 
 @Route('mongotest')
 export class MongoTestController extends Controller {
   @Post('create')
   @SuccessResponse('200', 'created')
   public async createTestData(
-    @Body() body: {
-      userId: number;
-      chatRoomId: string;
-      messageBody: string;
-    }
+    @Body() body: { userId: number; chatRoomId: string; messageBody: string }
   ): Promise<string> {
     const { userId, chatRoomId, messageBody } = body;
 
     const newMessage = await mongo.message.create({
       data: {
         userId,
-        chatRoodId: chatRoomId,
+        chatRoomId: chatRoomId,
         messageBody
       }
     });


### PR DESCRIPTION
### Pull Request 템플릿

## 🔗 관련 이슈 번호

> 이 PR이 연결된 이슈가 있다면 번호를 작성해주세요. (`#123` 형식)

예시:
- 관련 이슈: #45

---

## ✅ 작업 유형 (Tag)

- [X] ✨ Feature 
- [ ] 🐛 Fix 
- [ ] 🔨 Refactoring 
- [ ] 📝 Docs 

---

## ✏️ 수정 사항 및 개선 내용

> 어떤 내용을 수정하거나 개선했는지 상세히 작성해주세요.

1. 채팅방 메시지 조회 로직
채팅방에 입장했을때 보이는 메시지들을 조회 할 수 있도록 만들었습니다.

GET : /chat?chatRoomId= 

해당 채팅방에 존재하는 모든 메시지를 배열형태로 받아 올 수 있습니다.
<img width="539" height="321" alt="image" src="https://github.com/user-attachments/assets/6761ab2b-3088-465a-ad35-2672c41b9b6b" />

다음처럼 보낸유저userId, 메시지 내용, 발송된 날짜, 사진인지여부, 확인 여부를 볼 수 있습니다.
가장 최근에 보낸 데이터가 위로 가도록 순서를 정했습니다

2. 채팅방 메시지 전송 로직

POST : /chat/message?chatRoomId=

채팅방에 대해 메시지를 전송하는 로직을 구현했습니다.
<img width="973" height="277" alt="image" src="https://github.com/user-attachments/assets/06400be5-f55a-4d9e-9734-01014d09837a" />
소켓 이벤트 리스너를 통해 테스트 가능하며 보낼때, 받을때 인자를 정확히 명시 해야합니다.
상대가 접속중이지 않을때 예외처리를 생각해봤는데 어차피 DB를 기준으로 채팅을 관리하고, 실시간으로 알람이 가지는 않으니 예외처리 하지 않았습니다. 또한 가장 최근에 발송된 메시지를 lastMessege를 업데이트해 채팅방 목록조회할때 확인 가능하게 하고, check을 통해 이 메시지를 읽었는지 여부또한 확인 가능하도록 만들었습니다.

3.채팅방 목록 조회

GET: /chat/rooms

<img width="619" height="119" alt="image" src="https://github.com/user-attachments/assets/ebfad302-db94-4056-8194-fc6b974073f6" />

유저 본인의 채팅방 목록을 확인할 수 있도록 하였습니다. 


4. 채팅시작

POST :  /chat/start

상대방 유저 userID를 인수로 받아 chatRoomId를 만드는 로직을 구현했습니다.
만약 상대방과 처음 채팅을 한다면 새로 만들어진 chatRoomId를 반환하고, 만약 이미 chatRoomId가 존재한다면 해당 값을 반환해줍니다.

---

## ⚠️ 문제 발생 여부 및 상세 위치
---

## 📋 TODO List

> 남은 작업이나 추가로 처리해야 할 항목이 있다면 체크리스트로 작성해주세요.

1. 사진 업로드 관련 - 채팅방에 사진을 업로드 할 수 있습니다. 이 경우 isPhoto 값을 true로 하고 messageBody에 사진 url을 넣는 방향으로 추가 구현하면 될것 같습니다.
2. 채팅 읽기 로직 - 채팅방을 들어갔을때 안읽은 채팅들을 확인 하는 로직이 필요합니다
