### PR TITLE
fix: 유저 시간표 기본 업로드

### DIFF
--- a/src/profile/profile.Controller.ts
+++ b/src/profile/profile.Controller.ts
@@ -289,33 +289,33 @@ export class ProfileController extends Controller {
    * @param timeLine - 시간표 데이터
    * @returns 업로드 성공
    */
-  @Post('/postTimeLine')
-  @Security('jwt_token')
-  @SuccessResponse(200, '시간표 업로드 성공')
-  @Response<ITsoaErrorResponse>(409, '시간표 업로드 실패', {
-    resultType: 'FAIL',
-    error: {
-      errorCode: 'PR-04',
-      reason: '이미 시간표가 존재합니다.',
-      data: null
-    },
-    success: null
-  })
-  public async postTimeLine(
-    @Request() req: Express.Request,
-    @Query() timeLine: string
-  ): Promise<ITsoaSuccessResponse<string>> {
-    if (!req.user || !req.user.index) {
-      throw new UserUnauthorizedError('유저 인증 정보가 없습니다.');
-    }
+  // @Post('/postTimeLine')
+  // @Security('jwt_token')
+  // @SuccessResponse(200, '시간표 업로드 성공')
+  // @Response<ITsoaErrorResponse>(409, '시간표 업로드 실패', {
+  //   resultType: 'FAIL',
+  //   error: {
+  //     errorCode: 'PR-04',
+  //     reason: '이미 시간표가 존재합니다.',
+  //     data: null
+  //   },
+  //   success: null
+  // })
+  // public async postTimeLine(
+  //   @Request() req: Express.Request,
+  //   @Query() timeLine: string
+  // ): Promise<ITsoaSuccessResponse<string>> {
+  //   if (!req.user || !req.user.index) {
+  //     throw new UserUnauthorizedError('유저 인증 정보가 없습니다.');
+  //   }
 
-    const result = await this.profileService.postTimeLineService(
-      req.user.index,
-      timeLine
-    );
+  //   const result = await this.profileService.postTimeLineService(
+  //     req.user.index,
+  //     timeLine
+  //   );
 
-    return new TsoaSuccessResponse<string>(result);
-  }
+  //   return new TsoaSuccessResponse<string>(result);
+  // }
 
   /**
    * 유저의 시간표를 조회한다.

--- a/src/user/user.Model.ts
+++ b/src/user/user.Model.ts
@@ -76,6 +76,13 @@ export class UserModel {
     await prisma.specifyInfo.create({
       data: { userId: createdUser.userId, info: [] }
     });
+
+    await prisma.userTimetable.create({
+      data: {
+        userId: createdUser.userId,
+        timetable: '0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+      }
+    });
   }
   public async deleteRefreshToken(userId: number) {
     await prisma.refeshToken.delete({


### PR DESCRIPTION
### Pull Request 템플릿

## 🔗 관련 이슈 번호

> 이 PR이 연결된 이슈가 있다면 번호를 작성해주세요. (`#123` 형식)

예시:
- 관련 이슈: #45
#224
---

## ✅ 작업 유형 (Tag)

- [ ] ✨ Feature 
- [ ] 🐛 Fix 
- [ ] 🔨 Refactoring 
- [ ] 📝 Docs 

---

## ✏️ 수정 사항 및 개선 내용

> 어떤 내용을 수정하거나 개선했는지 상세히 작성해주세요.

예시:
- 로그인 API에서 JWT 생성 방식 변경
- 응답 형식에 `userId` 추가

유저 회원가입 시 빈 시간표 추가합니다.
postTimeline api 주석처리하여 제거했습니다. 이제 수정 api만 사용합니다.

---

## ⚠️ 문제 발생 여부 및 상세 위치

- [ ] 문제 없음
- [ ] 문제 발생함

> 문제가 발생한 경우 어떤 코드/상황에서 발생했는지 구체적으로 작성해주세요.

예시:
- user.Server.ts에서 CORS 오류 발생
- Prisma client 관련 의존성 충돌

---

## 📋 TODO List

> 남은 작업이나 추가로 처리해야 할 항목이 있다면 체크리스트로 작성해주세요.

- [ ] 테스트 코드 작성
- [ ] Swagger 문서 반영
- [ ] 코드 리뷰 반영
- [ ] 배포 전 최종 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * New users now receive a default, empty timetable automatically upon account creation, reducing setup steps and ensuring a consistent starting state.

* Chores
  * Removed the POST /postTimeLine API endpoint. Clients relying on this route will need to migrate to alternative workflows; other profile endpoints remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->