### PR TITLE
[fix] messageShowUp userId

### DIFF
--- a/src/coffeeChat/coffeeChat.Model.ts
+++ b/src/coffeeChat/coffeeChat.Model.ts
@@ -945,12 +945,22 @@ export class HomeModel {
     const result = await prisma.coffeeChat.findFirstOrThrow({
       where : {
         coffectId : coffectId,
-        secondUserId : userId
+        OR : [
+          { firstUserId : userId },
+          { secondUserId : userId }
+        ]
       }, 
       select : {
         coffectId : true,
         firstUserId : true,
+        secondUserId : true,
         firstUser : {
+          select : {
+            userId : true,
+            name : true
+          }
+        },
+        secondUser : {
           select : {
             userId : true,
             name : true
@@ -961,10 +971,24 @@ export class HomeModel {
       }
     });
 
+    // userId가 firstUserId인지 secondUserId인지 확인하여 상대방 정보 반환
+    let opponentUserId: number;
+    let opponentName: string;
+
+    if (result.firstUserId === userId) {
+      // 현재 사용자가 firstUserId인 경우, secondUser 정보 반환
+      opponentUserId = result.secondUserId;
+      opponentName = result.secondUser.name;
+    } else {
+      // 현재 사용자가 secondUserId인 경우, firstUser 정보 반환
+      opponentUserId = result.firstUserId;
+      opponentName = result.firstUser.name;
+    }
+
     return new CoffeeChatShowUpDTO(
       result.coffectId,
-      result.firstUserId,
-      result.firstUser.name,
+      opponentUserId,
+      opponentName,
       result.message || '',
       result.createdAt
     );


### PR DESCRIPTION
### Pull Request 템플릿

## 🔗 관련 이슈 번호

> 이 PR이 연결된 이슈가 있다면 번호를 작성해주세요. (`#123` 형식)

- 관련 이슈: 

---

## ✅ 작업 유형 (Tag)

- [ ] ✨ Feature 
- [X] 🐛 Fix 
- [ ] 🔨 Refactoring 
- [ ] 📝 Docs 

---

## ✏️ 수정 사항 및 개선 내용

> 어떤 내용을 수정하거나 개선했는지 상세히 작성해주세요.

* firstUserID면 secondUserID 반환
* secondUserID 면 firstUserID 반환
* 으로 로직 수정

---

## ⚠️ 문제 발생 여부 및 상세 위치

- [ ] 문제 없음
- [ ] 문제 발생함

> 문제가 발생한 경우 어떤 코드/상황에서 발생했는지 구체적으로 작성해주세요.

예시:
- user.Server.ts에서 CORS 오류 발생
- Prisma client 관련 의존성 충돌

---

## 📋 TODO List

> 남은 작업이나 추가로 처리해야 할 항목이 있다면 체크리스트로 작성해주세요.

- [ ] 테스트 코드 작성
- [ ] Swagger 문서 반영
- [ ] 코드 리뷰 반영
- [ ] 배포 전 최종 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Coffee Chat Show Up now finds your chat whether you’re the first or second participant, reducing missed or hidden chats.
  - Opponent details (name and ID) are correctly determined and displayed by identifying the other participant.
  - Ensures consistent display of existing fields (message, created time) regardless of participant order.
  - Improves reliability when accessing chats from different user roles, preventing incorrect assumptions about participant positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->