### PR TITLE
fix : date to string all message

### DIFF
--- a/prisma/mongodb/schema.prisma
+++ b/prisma/mongodb/schema.prisma
@@ -14,7 +14,7 @@ model Message {
   chatRoomId String
   isPhoto Boolean @default(false)
   messageBody   String
-  createdAt DateTime @default(now())
+  createdAt String
   check Boolean @default(false)
   
   @@index([userId], map: "Message_senderId_idx")

--- a/src/chat/chat.Service.ts
+++ b/src/chat/chat.Service.ts
@@ -64,7 +64,7 @@ export class ChatService {
       );
       if (lastMessage) {
         room.lastMessage = lastMessage.messageBody;
-        room.lastMessageTime = lastMessage.createdAt;
+        room.lastMessageTime = lastMessage.createdAt; // string으로 일치
       }
       resultInfo.push(room);
     }

--- a/src/config/KSTtime.ts
+++ b/src/config/KSTtime.ts
@@ -18,5 +18,5 @@ export const KSTtimeToISOString = () => {
   const seconds = String(kstTime.getUTCSeconds()).padStart(2, '0');
   const milliseconds = String(kstTime.getUTCMilliseconds()).padStart(3, '0');
   
-  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}.${milliseconds}+09:00`;
+  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}.${milliseconds}`;
 };

--- a/src/middleware/chat.DTO/chat.DTO.ts
+++ b/src/middleware/chat.DTO/chat.DTO.ts
@@ -9,7 +9,7 @@ export interface ChatRoomInfoDTO {
   userId: number;
   lastMessage: string | null;
   check: boolean | null;
-  lastMessageTime: Date | null; // 오타 수정 lastMeesageTime → lastMessageTime
+  lastMessageTime: string | null; // 오타 수정 lastMeesageTime → lastMessageTime
 }
 
 export interface ChatDataDTO {
@@ -17,7 +17,7 @@ export interface ChatDataDTO {
   chatRoomId: string;
   userId: number;
   messageBody: string;
-  createdAt: Date;
+  createdAt: string;
   isPhoto: boolean;
   check: boolean;
 }

--- a/src/thread/mongotest.Controller.ts
+++ b/src/thread/mongotest.Controller.ts
@@ -14,7 +14,10 @@ export class MongoTestController extends Controller {
       data: {
         userId,
         chatRoomId: chatRoomId,
-        messageBody
+        messageBody,
+        createdAt: new Date().toISOString(),
+        isPhoto: false,
+        check: false
       }
     });
 

--- a/src/user/user.Model.ts
+++ b/src/user/user.Model.ts
@@ -196,6 +196,11 @@ export class UserModel {
         where: { userId: userId }
       });
 
+      // 8-1. 사용자가 다른 글에 남긴 Comment 삭제
+      await tx.comment.deleteMany({
+        where: { userId: userId }
+      });
+
       // 9. ChatRoomUser 삭제
       await tx.chatRoomUser.deleteMany({
         where: { userId: userId }
@@ -247,6 +252,20 @@ export class UserModel {
       });
 
       // 18. ThreadScrap 삭제
+      // 18-1. 사용자의 ThreadScrap 목록 조회 후 ScrapMatch 먼저 정리
+      const userScraps = await tx.threadScrap.findMany({
+        where: { userId: userId },
+        select: { scrapId: true }
+      });
+
+      const scrapIds = userScraps.map((scrap) => scrap.scrapId);
+      if (scrapIds.length > 0) {
+        await tx.scrapMatch.deleteMany({
+          where: { scrapId: { in: scrapIds } }
+        });
+      }
+
+      // 18-2. ThreadScrap 삭제
       await tx.threadScrap.deleteMany({
         where: { userId: userId }
       });


### PR DESCRIPTION
### Pull Request 템플릿

## 🔗 관련 이슈 번호

> 이 PR이 연결된 이슈가 있다면 번호를 작성해주세요. (`#123` 형식)

예시:
- 관련 이슈: #45

---

## ✅ 작업 유형 (Tag)

- [ ] ✨ Feature 
- [ ] 🐛 Fix 
- [ ] 🔨 Refactoring 
- [ ] 📝 Docs 

---

## ✏️ 수정 사항 및 개선 내용

> 어떤 내용을 수정하거나 개선했는지 상세히 작성해주세요.

예시:
- 로그인 API에서 JWT 생성 방식 변경
- 응답 형식에 `userId` 추가

---

## ⚠️ 문제 발생 여부 및 상세 위치

- [ ] 문제 없음
- [ ] 문제 발생함

> 문제가 발생한 경우 어떤 코드/상황에서 발생했는지 구체적으로 작성해주세요.

예시:
- user.Server.ts에서 CORS 오류 발생
- Prisma client 관련 의존성 충돌

---

## 📋 TODO List

> 남은 작업이나 추가로 처리해야 할 항목이 있다면 체크리스트로 작성해주세요.

- [ ] 테스트 코드 작성
- [ ] Swagger 문서 반영
- [ ] 코드 리뷰 반영
- [ ] 배포 전 최종 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized message timestamps to strings across chat APIs; KST-formatted timestamps no longer include the “+09:00” suffix.
  - Chat responses now use a consistent DTO, returning id, chatRoomId, userId, messageBody, createdAt (string), isPhoto, and check.

- Bug Fixes
  - Account deletion now also removes the user’s comments and related scrap matches, preventing orphaned data and ensuring cleaner data cleanup.

- Chores
  - Added default fields (createdAt, isPhoto, check) when creating messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->