### PR TITLE
feat: thread/main api에 인기순 조회 추가

### DIFF
--- a/src/middleware/thread.DTO/thread.DTO.ts
+++ b/src/middleware/thread.DTO/thread.DTO.ts
@@ -28,20 +28,20 @@ export class BodyToAddThread {
 }
 
 export class BodyToLookUpMainThread {
-  type: Thread_type;
-  threadSubject: number[];
+  type?: Thread_type;
+  threadSubject?: number[];
   orderBy: 'createdAt' | 'likeCount';
   dateCursor?: Date;
 
   constructor(body: {
-    type: Thread_type;
-    threadSubject: number[];
+    type?: Thread_type;
+    threadSubject?: number[];
     dateCursor?: Date;
     orderBy?: 'createdAt' | 'likeCount';
   }) {
     this.type = body.type;
     this.orderBy = body.orderBy ?? 'createdAt'; // 기본값은 createdAt
-    this.threadSubject = body.threadSubject ?? []; // 기본값은 빈 배열
+    this.threadSubject = body.threadSubject; // 기본값은 빈 배열
     this.dateCursor = body.dateCursor;
   }
 }

--- a/src/middleware/univ.DTO/univ.DTO.ts
+++ b/src/middleware/univ.DTO/univ.DTO.ts
@@ -11,9 +11,9 @@ export class UnivCertRespone {
 }
 export class UnivCertBody {
   @Example(123456)
-  certCode!: number;
+    certCode!: number;
   @Example('seoki180@inha.edu')
-  email!: string;
+    email!: string;
 }
 export class UnivCertRequest {
   certCode: number;
@@ -32,7 +32,7 @@ export type UnivList = {
 
 export class UnivSearchBody {
   @Example('인하')
-  univName!: string;
+    univName!: string;
 }
 
 export class UnivSearchResponse {
@@ -51,9 +51,9 @@ type DeptList = {
 };
 export class DeptSearchBody {
   @Example('인하')
-  univName!: string;
+    univName!: string;
   @Example('컴퓨터공학과')
-  search!: string;
+    search!: string;
 }
 export class DeptSearchResponse {
   deptList: DeptList[];
@@ -65,7 +65,7 @@ export class DeptSearchResponse {
 
 export class UnivDomainBody {
   @Example('seoki180@inha.edu')
-  email!: string;
+    email!: string;
   @Example('인하대학교')
-  univ!: string;
+    univ!: string;
 }

--- a/src/thread/thread.Controller.ts
+++ b/src/thread/thread.Controller.ts
@@ -244,8 +244,8 @@ export class ThreadController extends Controller {
   public async mainThread(
     @Request() req: ExpressRequest,
     @Body() body: {
-      type: Thread_type;
-      threadSubject: number[];
+      type?: Thread_type;
+      threadSubject?: number[];
       orderBy: 'createdAt' | 'likeCount';
       dateCursor?: Date
     }

--- a/src/thread/thread.Service.ts
+++ b/src/thread/thread.Service.ts
@@ -75,6 +75,7 @@ export class ThreadService {
     return reform;
   };
 
+  // 필터링 있는 최신순 조회
   public lookUpThreadMainService = async (
     body: BodyToLookUpMainThread,
     userId: number
@@ -84,7 +85,14 @@ export class ThreadService {
     if(body.orderBy === 'createdAt'){
       results = await this.ThreadModel.lookUpThreadMainRepository(body, userId);  
     }else{
-      results = await this.ThreadModel.lookUpThreadMainByLikesRepository(body, userId);
+      if(body.type === undefined && body.threadSubject === undefined){
+        console.log('필터링 없는 좋아요 조회');
+        results = await this.ThreadModel.threadByLikesRepository(userId);
+      }else{
+        results = await this.ThreadModel.lookUpThreadMainByLikesRepository(body, userId);
+      }
+
+      console.log(results);
       
       if(results === null){
         return {thread: [], nextCursor: null};
@@ -109,6 +117,7 @@ export class ThreadService {
     return { thread, nextCursor: results.nextCursor };
   };
 
+  // 필터링 없는 최신순 조회
   public lookUpLatestThreadMainService = async (
     userId: number,
     dateCursor?: Date
@@ -130,6 +139,7 @@ export class ThreadService {
     return { thread, nextCursor: results.nextCursor };
   };
 
+  // 필터링 없이 좋아요 순으로 게시글 조회
   public lookUpLikesThreadService = async (
     userId: number
   ): Promise<ResponseFromThreadMainCursorToClient> => {


### PR DESCRIPTION
### Pull Request 템플릿

## 🔗 관련 이슈 번호

> 이 PR이 연결된 이슈가 있다면 번호를 작성해주세요. (`#123` 형식)

예시:
- 관련 이슈: #45

---

## ✅ 작업 유형 (Tag)

- [x] ✨ Feature 
- [ ] 🐛 Fix 
- [ ] 🔨 Refactoring 
- [ ] 📝 Docs 

---

## ✏️ 수정 사항 및 개선 내용

> 어떤 내용을 수정하거나 개선했는지 상세히 작성해주세요.

예시:
- 로그인 API에서 JWT 생성 방식 변경
- 응답 형식에 `userId` 추가

subject와 type 없이도 인기순 조회 가능

---

## ⚠️ 문제 발생 여부 및 상세 위치

- [ ] 문제 없음
- [ ] 문제 발생함

> 문제가 발생한 경우 어떤 코드/상황에서 발생했는지 구체적으로 작성해주세요.

예시:
- user.Server.ts에서 CORS 오류 발생
- Prisma client 관련 의존성 충돌

---

## 📋 TODO List

> 남은 작업이나 추가로 처리해야 할 항목이 있다면 체크리스트로 작성해주세요.

- [ ] 테스트 코드 작성
- [ ] Swagger 문서 반영
- [ ] 코드 리뷰 반영
- [ ] 배포 전 최종 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Main thread feed now supports viewing by Latest or Most Liked.
  - Thread filters (type and subject) are now optional, allowing broader browsing without specifying filters.

- Improvements
  - Smarter fetching for the “Most Liked” view when no filters are applied.
  - More robust empty-state handling and consistent pagination for thread lists.

- Style
  - Minor formatting cleanups in university-related request bodies; no functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->